### PR TITLE
fixes issue w/ copying ZK from local dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN yum install -y java-1.8.0-openjdk-devel make gcc-c++ wget && \
   if [ -z "$ZOOKEEPER_FILE" ]; then \
     download "zookeeper.tar.gz" "zookeeper/zookeeper-$ZOOKEEPER_VERSION/apache-zookeeper-$ZOOKEEPER_VERSION-bin.tar.gz"; \
   else \
-    cp "/tmp/$ZOOKEEPER_FILE" "apache-zookeeper.tar.gz"; \
+    cp "/tmp/$ZOOKEEPER_FILE" "zookeeper.tar.gz"; \
   fi; \
   if [ -z "$ACCUMULO_FILE" ]; then \
     download "accumulo.tar.gz" "accumulo/$ACCUMULO_VERSION/accumulo-$ACCUMULO_VERSION-bin.tar.gz"; \


### PR DESCRIPTION
When using a local copy of ZK instead of downloading it, the local copy was being copied to the wrong filename inside the container.