### PR TITLE
Make rebuilding the docker image for a new Accumulo snapshot faster (ver 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,65 +15,29 @@
 
 FROM rockylinux:9
 
-ARG ACCUMULO_VERSION=2.1.0
-ARG HADOOP_VERSION=3.3.3
-ARG ZOOKEEPER_VERSION=3.8.0
 ARG HADOOP_USER_NAME=accumulo
-ARG ACCUMULO_FILE=
-ARG HADOOP_FILE=
-ARG ZOOKEEPER_FILE=
+ARG HADOOP_FILE=hadoop.tar.gz
+ARG ZOOKEEPER_FILE=zookeeper.tar.gz
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk HADOOP_USER_NAME=$HADOOP_USER_NAME
 
-ENV APACHE_DIST_URLS \
-  https://www.apache.org/dyn/closer.cgi?action=download&filename= \
-# if the version is outdated (or we're grabbing the .asc file), we might have to pull from the dist/archive :/
-  https://www-us.apache.org/dist/ \
-  https://www.apache.org/dist/ \
-  https://archive.apache.org/dist/
-
-COPY README.md $ACCUMULO_FILE $HADOOP_FILE $ZOOKEEPER_FILE /tmp/
+COPY $HADOOP_FILE $ZOOKEEPER_FILE /tmp/
 
 RUN yum install -y ca-certificates java-11-openjdk-devel make gcc-c++ wget && \
   update-ca-trust extract && \
-  set -eux; \
-  download() { \
-    local f="$1"; shift; \
-    local distFile="$1"; shift; \
-    local success=; \
-    local distUrl=; \
-    for distUrl in $APACHE_DIST_URLS; do \
-      if wget -nv -O "$f" "$distUrl$distFile"; then \
-        success=1; \
-        break; \
-      fi; \
-    done; \
-    [ -n "$success" ]; \
-  }; \
-  \
-  if [ -z "$HADOOP_FILE" ]; then \
-    download "hadoop.tar.gz" "hadoop/core/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz"; \
-  else \
-    mv "/tmp/$HADOOP_FILE" "hadoop.tar.gz"; \
-  fi; \
-  if [ -z "$ZOOKEEPER_FILE" ]; then \
-    download "zookeeper.tar.gz" "zookeeper/zookeeper-$ZOOKEEPER_VERSION/apache-zookeeper-$ZOOKEEPER_VERSION-bin.tar.gz"; \
-  else \
-    mv "/tmp/$ZOOKEEPER_FILE" "zookeeper.tar.gz"; \
-  fi; \
-  if [ -z "$ACCUMULO_FILE" ]; then \
-    download "accumulo.tar.gz" "accumulo/$ACCUMULO_VERSION/accumulo-$ACCUMULO_VERSION-bin.tar.gz"; \
-  else \
-    mv "/tmp/$ACCUMULO_FILE" "accumulo.tar.gz"; \
-  fi && \
-  tar xzf accumulo.tar.gz -C /tmp/ && \
-  tar xzf hadoop.tar.gz -C /tmp/ && \
-  tar xzf zookeeper.tar.gz -C /tmp/ && \
-  mv /tmp/hadoop-$HADOOP_VERSION /opt/hadoop && \
-  mv /tmp/apache-zookeeper-$ZOOKEEPER_VERSION-bin /opt/zookeeper && \
-  mv /tmp/accumulo-$ACCUMULO_VERSION* /opt/accumulo && \
-  rm -f accumulo.tar.gz hadoop.tar.gz zookeeper.tar.gz && \
-  rm -rf /opt/hadoop/share/doc/hadoop && \
+  tar xzf /tmp/$HADOOP_FILE -C /tmp/ && \
+  tar xzf /tmp/$ZOOKEEPER_FILE -C /tmp/ && \
+  rm -f /tmp/$HADOOP_FILE /tmp/$ZOOKEEPER_FILE && \
+  mv /tmp/hadoop-* /opt/hadoop && \
+  mv /tmp/apache-zookeeper-*-bin /opt/zookeeper && \
+  rm -rf /opt/hadoop/share/doc/hadoop
+
+ARG ACCUMULO_FILE=accumulo.tar.gz
+COPY $ACCUMULO_FILE /tmp/
+
+RUN tar xzf /tmp/$ACCUMULO_FILE -C /tmp/ && \
+  rm -f /tmp/$ACCUMULO_FILE && \
+  mv /tmp/accumulo-* /opt/accumulo && \
   /opt/accumulo/bin/accumulo-util build-native
 
 ADD properties/ /opt/accumulo/conf/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN yum install -y ca-certificates java-11-openjdk-devel make gcc-c++ wget && \
   mv /tmp/apache-zookeeper-*-bin /opt/zookeeper && \
   rm -rf /opt/hadoop/share/doc/hadoop
 
+# Accumulo is built in a different run command so that rebuilding for a new
+# Accumulo snapshot tarball is faster.
 ARG ACCUMULO_FILE=accumulo.tar.gz
 COPY $ACCUMULO_FILE /tmp/
 

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,25 @@
+set -eux;
+
+ACCUMULO_VERSION="2.0.1"
+HADOOP_VERSION="3.2.1"
+ZOOKEEPER_VERSION="3.6.0"
+
+APACHE_DIST_URLS="https://www.apache.org/dyn/closer.cgi?action=download&filename= https://www-us.apache.org/dist/ https://www.apache.org/dist/ https://archive.apache.org/dist/"
+
+download() {
+  local f="$1"; shift;
+  local distFile="$1"; shift;
+  local success=;
+  local distUrl=;
+  for distUrl in $APACHE_DIST_URLS; do
+    if wget -nv -O "$f" "$distUrl$distFile"; then
+      success=1;
+      break;
+    fi;
+  done;
+  [ -n "$success" ];
+};
+
+download "hadoop.tar.gz" "hadoop/core/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz"; \
+download "zookeeper.tar.gz" "zookeeper/zookeeper-$ZOOKEEPER_VERSION/apache-zookeeper-$ZOOKEEPER_VERSION-bin.tar.gz"; \
+download "accumulo.tar.gz" "accumulo/$ACCUMULO_VERSION/accumulo-$ACCUMULO_VERSION-bin.tar.gz"; \


### PR DESCRIPTION
See #20 for background. This PR is a replacement of that PR based on feedback from that PR.  

This PR used a single docker file and broke the work into 2 run commands.  With this structure in the docker file, when there is a new accumulo snapshot tarball it only rebuilds the accumulo and later layers.  Takes 5 seconds.  Two docker files as in #20 is a bit faster because it does not have to upload the hadoop and ZK tarballs for the accumulo only build.  However that is only a few seconds and the extra complexity would not make that worthwhile.

Setting this as a draft again as I have not updated the README.  @brianloss and @dlmarion how do these changes look?