### PR TITLE
Refactor Docker image to allow faster rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,72 +13,110 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rockylinux:9
 
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+##
+## Base image. Rocky Linux 9 with updates, JRE 11 headless, and updated CA certs.
+##
+FROM rockylinux:9 as base
+
+RUN set -eux; \
+  yum install -y ca-certificates java-11-openjdk-headless && \
+  update-ca-trust extract && \
+  yum clean all && \
+  rm -rf /var/cache/yum
+
+##
+## Base image for building. Adds wget, JDK and make (for building Accumulo native libs).
+##
+FROM base as buildbase
+
+RUN set -eux; \
+  yum install -y java-11-openjdk-devel make gcc-c++ wget && \
+  update-ca-trust extract
+
+COPY download.sh /usr/local/bin/
+
+##
+## Hadoop image. Download/copy and extract the Hadoop installation.
+##
+FROM buildbase as hadoop
+
 ARG HADOOP_VERSION=3.3.3 \
-  ZOOKEEPER_VERSION=3.8.0 \
-  HADOOP_FILE=_NOT_SET \
-  ZOOKEEPER_FILE=_NOT_SET
+  HADOOP_FILE=_NOT_SET
 
 # Copy a known file along with the optional files (that might not exist).
-# The known file, along with '*' for the optional files allows the command
-# to succeed even if the optional files do not exist. If we used an empty
-# string for the optional files default value, then this command would copy
+# The known file, along with '*' for the optional file allows the command
+# to succeed even if the optional file does not exist. If we used an empty
+# string for the optional file default value, then this command would copy
 # the entire build context, which is not what we want.
-COPY asf_download.sh ${HADOOP_FILE}* ${ZOOKEEPER_FILE}* /tmp/
+COPY download.sh ${HADOOP_FILE}* /tmp/
 
-RUN yum install -y ca-certificates java-11-openjdk-devel make gcc-c++ wget && \
-  update-ca-trust extract && \
-  set -eux; \
-  \
-  if [ "$HADOOP_FILE" == "_NOT_SET" ]; then \
-    /tmp/asf_download.sh "hadoop.tar.gz" "hadoop/core/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz"; \
-  else \
-    mv "/tmp/$HADOOP_FILE" "hadoop.tar.gz"; \
-  fi; \
-  if [ "$ZOOKEEPER_FILE" == "_NOT_SET" ]; then \
-    /tmp/asf_download.sh "zookeeper.tar.gz" "zookeeper/zookeeper-$ZOOKEEPER_VERSION/apache-zookeeper-$ZOOKEEPER_VERSION-bin.tar.gz"; \
-  else \
-    mv "/tmp/$ZOOKEEPER_FILE" "zookeeper.tar.gz"; \
-  fi; \
-  tar xzf hadoop.tar.gz -C /tmp/ && \
-  tar xzf zookeeper.tar.gz -C /tmp/ && \
-  mv /tmp/hadoop-$HADOOP_VERSION /opt/hadoop && \
-  mv /tmp/apache-zookeeper-$ZOOKEEPER_VERSION-bin /opt/zookeeper && \
-  rm -f hadoop.tar.gz zookeeper.tar.gz && \
+RUN set -eux; \
+  download.sh "${HADOOP_FILE}" "hadoop.tar.gz" "hadoop/core/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz"; \
+  tar xzf hadoop.tar.gz -C /tmp/; \
+  mv /tmp/hadoop-$HADOOP_VERSION /opt/hadoop; \
   rm -rf /opt/hadoop/share/doc/hadoop
+
+##
+## Zookeeper image. Download/copy and extract the Zookeeper installation.
+##
+FROM buildbase as zookeeper
+
+ARG ZOOKEEPER_VERSION=3.8.0 \
+  ZOOKEEPER_FILE=_NOT_SET
+# Copy a known file along with the optional files (that might not exist).
+# The known file, along with '*' for the optional file allows the command
+# to succeed even if the optional file does not exist. If we used an empty
+# string for the optional file default value, then this command would copy
+# the entire build context, which is not what we want.
+COPY download.sh ${ZOOKEEPER_FILE}* /tmp/
+
+RUN set -eux; \
+  download.sh "${ZOOKEEPER_FILE}" "zookeeper.tar.gz" "zookeeper/zookeeper-$ZOOKEEPER_VERSION/apache-zookeeper-$ZOOKEEPER_VERSION-bin.tar.gz"; \
+  tar xzf zookeeper.tar.gz -C /tmp/; \
+  mv /tmp/apache-zookeeper-$ZOOKEEPER_VERSION-bin /opt/zookeeper
+
+##
+## Accumulo image. Download/copy and extract the Accumulo installation, build native libs, and copy in properties.
+##
+FROM buildbase as accumulo
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 
 ARG ACCUMULO_VERSION=2.1.0 \
   ACCUMULO_FILE=_NOT_SET
 # Copy a known file along with the optional files (that might not exist).
-# The known file, along with '*' for the optional files allows the command
-# to succeed even if the optional files do not exist. If we used an empty
-# string for the optional files default value, then this command would copy
+# The known file, along with '*' for the optional file allows the command
+# to succeed even if the optional file does not exist. If we used an empty
+# string for the optional file default value, then this command would copy
 # the entire build context, which is not what we want.
-COPY asf_download.sh ${ACCUMULO_FILE}* /tmp/
+COPY download.sh ${ACCUMULO_FILE}* /tmp/
 
 RUN set -eux; \
-  \
-  if [ "$ACCUMULO_FILE" == "_NOT_SET" ]; then \
-    /tmp/asf_download.sh "accumulo.tar.gz" "accumulo/$ACCUMULO_VERSION/accumulo-$ACCUMULO_VERSION-bin.tar.gz"; \
-  else \
-    mv "/tmp/$ACCUMULO_FILE" "accumulo.tar.gz"; \
-  fi && \
-  rm /tmp/asf_download.sh && \
-  tar xzf accumulo.tar.gz -C /tmp/ && \
-  mv /tmp/accumulo-$ACCUMULO_VERSION*/ /opt/accumulo && \
-  rm -f accumulo.tar.gz && \
+  download.sh "${ACCUMULO_FILE}" "accumulo.tar.gz" "accumulo/$ACCUMULO_VERSION/accumulo-$ACCUMULO_VERSION-bin.tar.gz"; \
+  tar xzf accumulo.tar.gz -C /tmp/; \
+  mv /tmp/accumulo-$ACCUMULO_VERSION*/ /opt/accumulo; \
   /opt/accumulo/bin/accumulo-util build-native
 
 ADD properties/ /opt/accumulo/conf/
 
+##
+## Final image. Copy extracted/built installations for hadoop, zookeeper, and accumulo.
+## Also set environment variables and entrypoint.
+##
+FROM base
+
 ARG HADOOP_USER_NAME=accumulo
-ENV HADOOP_HOME=/opt/hadoop \
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk \
+  HADOOP_HOME=/opt/hadoop \
   HADOOP_USER_NAME=$HADOOP_USER_NAME \
   ZOOKEEPER_HOME=/opt/zookeeper \
   ACCUMULO_HOME=/opt/accumulo \
   PATH="$PATH:/opt/accumulo/bin"
+
+COPY --from=hadoop /opt/hadoop /opt/hadoop
+COPY --from=zookeeper /opt/zookeeper /opt/zookeeper
+COPY --from=accumulo /opt/accumulo /opt/accumulo
 
 ENTRYPOINT ["accumulo"]
 CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY download.sh ${HADOOP_FILE}* /tmp/
 RUN set -eux; \
   download.sh "${HADOOP_FILE}" "hadoop.tar.gz" "hadoop/core/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz"; \
   tar xzf hadoop.tar.gz -C /tmp/; \
-  mv /tmp/hadoop-$HADOOP_VERSION /opt/hadoop; \
+  mv /tmp/hadoop-*/ /opt/hadoop; \
   rm -rf /opt/hadoop/share/doc/hadoop
 
 ##
@@ -74,7 +74,7 @@ COPY download.sh ${ZOOKEEPER_FILE}* /tmp/
 RUN set -eux; \
   download.sh "${ZOOKEEPER_FILE}" "zookeeper.tar.gz" "zookeeper/zookeeper-$ZOOKEEPER_VERSION/apache-zookeeper-$ZOOKEEPER_VERSION-bin.tar.gz"; \
   tar xzf zookeeper.tar.gz -C /tmp/; \
-  mv /tmp/apache-zookeeper-$ZOOKEEPER_VERSION-bin /opt/zookeeper
+  mv /tmp/apache-zookeeper-*/ /opt/zookeeper
 
 ##
 ## Accumulo image. Download/copy and extract the Accumulo installation, build native libs, and copy in properties.
@@ -95,7 +95,7 @@ COPY download.sh ${ACCUMULO_FILE}* /tmp/
 RUN set -eux; \
   download.sh "${ACCUMULO_FILE}" "accumulo.tar.gz" "accumulo/$ACCUMULO_VERSION/accumulo-$ACCUMULO_VERSION-bin.tar.gz"; \
   tar xzf accumulo.tar.gz -C /tmp/; \
-  mv /tmp/accumulo-$ACCUMULO_VERSION*/ /opt/accumulo; \
+  mv /tmp/accumulo-*/ /opt/accumulo; \
   /opt/accumulo/bin/accumulo-util build-native
 
 ADD properties/ /opt/accumulo/conf/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ While it is easier to pull from DockerHub, the image will default to the softwar
 |-------------|---------------|
 | [Accumulo]  | 2.1.0         |
 | [Hadoop]    | 3.3.3         |
-| [ZooKeeper] | 3.7.1         |
+| [ZooKeeper] | 3.8.0         |
 
 If these versions do not match what is running on your cluster, you should consider building
 your own image with matching versions. However, Accumulo must be 2.0.0+. Below are instructions for

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ building an image:
 
    Or build with an Accumulo tarball (located in same directory as DockerFile) using the command below:
 
-        docker build --build-arg ACCUMULO_VERSION=2.0.0-SNAPSHOT --build-arg ACCUMULO_FILE=accumulo-2.0.0-SNAPSHOT-bin.tar.gz -t accumulo .
+        docker build --build-arg --build-arg ACCUMULO_FILE=accumulo-2.0.0-SNAPSHOT-bin.tar.gz -t accumulo .
 
 ## Image basics
 

--- a/asf_download.sh
+++ b/asf_download.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+APACHE_DIST_URLS=(
+  "https://www.apache.org/dyn/closer.cgi?action=download&filename="
+  # if the version is outdated (or we're grabbing the .asc file), we might have to pull from the dist/archive :/
+  "https://www-us.apache.org/dist/"
+  "https://www.apache.org/dist/"
+  "https://archive.apache.org/dist/"
+)
+
+f="$1"; shift;
+distFile="$1"; shift;
+success=;
+distUrl=;
+for distUrl in "${APACHE_DIST_URLS[@]}"; do
+    echo "Attempting to fetch $distFile from $distUrl"
+    if wget -nv -O "$f" "$distUrl$distFile"; then
+    success=1;
+    break;
+    fi;
+done
+[ -n "$success" ]

--- a/download.sh
+++ b/download.sh
@@ -25,15 +25,28 @@ APACHE_DIST_URLS=(
   "https://archive.apache.org/dist/"
 )
 
-f="$1"; shift;
-distFile="$1"; shift;
-success=;
-distUrl=;
-for distUrl in "${APACHE_DIST_URLS[@]}"; do
-    echo "Attempting to fetch $distFile from $distUrl"
+download() {
+  local f="$1"; shift
+  local distFile="$1"; shift
+  local success=
+  local distUrl=
+  for distUrl in "${APACHE_DIST_URLS[@]}"; do
+    echo "Attempting to fetch $f from $distUrl$distFile"
     if wget -nv -O "$f" "$distUrl$distFile"; then
-    success=1;
-    break;
-    fi;
-done
-[ -n "$success" ]
+      success=1
+      break
+    fi
+  done
+  [ -n "$success" ]
+}
+
+existing_file=$1
+download_file=$2
+dist_file=$3
+
+if [ -f "/tmp/$existing_file" ]; then
+  echo "Skipping download of $existing_file"
+  mv "/tmp/$existing_file" "$download_file"
+else
+  download "$download_file" "$dist_file"
+fi

--- a/download.sh
+++ b/download.sh
@@ -44,9 +44,10 @@ existing_file=$1
 download_file=$2
 dist_file=$3
 
-if [ -f "/tmp/$existing_file" ]; then
+if [[ "$existing_file" == "_NOT_SET" ]]; then
+  download "$download_file" "$dist_file"
+else
+  [ -f "/tmp/$existing_file" ] || { echo "Existing file $existing_file does not exist"; exit 1; }
   echo "Skipping download of $existing_file"
   mv "/tmp/$existing_file" "$download_file"
-else
-  download "$download_file" "$dist_file"
 fi


### PR DESCRIPTION
Convert the existing Docker image into a multi-stage image with
independent layers for the base, Hadoop, Zookeeper, and Accumulo tarball
download/extraction (and native library build in the Accumulo case).
By having each install come from a separate base image, we can modify
the file/version for any of the packages and reuse the build cached for
the others, which greatly improves build times for a developer who is
iterating on Accumulo, for example. Also, by using a separate builder
base, the larger JDK and make tools were installed to build the Accumulo
native libraries, but then those tools are not included in the final
image.