### PR TITLE
Add all markdown files to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 .git/
-CONTRIBUTING.md
+*.md
 Dockerfile
 LICENSE
 NOTICE


### PR DESCRIPTION
This PR makes it to that all markdown files will be ignored by docker. Before this change, only `CONTRIBUTING.md` would be ignored. Now the README.md will also be ignored.