### PR TITLE
Bump accumulo, zookeeper, hadoop versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY download.sh /usr/local/bin/
 ##
 FROM buildbase as hadoop
 
-ARG HADOOP_VERSION=3.3.4 \
+ARG HADOOP_VERSION=3.3.6 \
   HADOOP_FILE=_NOT_SET
 
 # Copy a known file along with the optional files (that might not exist).
@@ -62,7 +62,7 @@ RUN set -eux; \
 ##
 FROM buildbase as zookeeper
 
-ARG ZOOKEEPER_VERSION=3.8.0 \
+ARG ZOOKEEPER_VERSION=3.8.2 \
   ZOOKEEPER_FILE=_NOT_SET
 # Copy a known file along with the optional files (that might not exist).
 # The known file, along with '*' for the optional file allows the command
@@ -83,7 +83,7 @@ FROM buildbase as accumulo
 
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 
-ARG ACCUMULO_VERSION=2.1.0 \
+ARG ACCUMULO_VERSION=2.1.2 \
   ACCUMULO_FILE=_NOT_SET
 # Copy a known file along with the optional files (that might not exist).
 # The known file, along with '*' for the optional file allows the command

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ building an image:
 
    Or build with an Accumulo tarball (located in same directory as DockerFile) using the command below:
 
-        docker build --build-arg ACCUMULO_FILE=accumulo-2.1.2-SNAPSHOT-bin.tar.gz -t accumulo .
+        docker build --build-arg ACCUMULO_FILE=accumulo-<version>-bin.tar.gz -t accumulo .
 
 ## Image basics
 
@@ -118,7 +118,7 @@ monitor but it can be modified to start other Accumulo services such as
 `master`, `tserver` and `gc`. For tablet servers, set `instances` to the number
 of tablet servers that you want to run.
 
-```
+```json
 {
   "id": "accumulo-monitor",
   "cmd": "accumulo monitor -o instance.secret=mysecret -o instance.volumes=hdfs://localhost:8020/accumulo -o instance.zookeeper.host=localhost:2181",

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ While it is easier to pull from DockerHub, the image will default to the softwar
 
 | Software    | Version       |
 |-------------|---------------|
-| [Accumulo]  | 2.1.0         |
-| [Hadoop]    | 3.3.4         |
-| [ZooKeeper] | 3.8.0         |
+| [Accumulo]  | 2.1.2         |
+| [Hadoop]    | 3.3.6         |
+| [ZooKeeper] | 3.8.2         |
 
 If these versions do not match what is running on your cluster, you should consider building
 your own image with matching versions. However, Accumulo must be 2.0.0+. Below are instructions for
@@ -39,7 +39,7 @@ building an image:
 
    Or build with an Accumulo tarball (located in same directory as DockerFile) using the command below:
 
-        docker build --build-arg ACCUMULO_FILE=accumulo-2.1.0-SNAPSHOT-bin.tar.gz -t accumulo .
+        docker build --build-arg ACCUMULO_FILE=accumulo-2.1.2-SNAPSHOT-bin.tar.gz -t accumulo .
 
 ## Image basics
 


### PR DESCRIPTION
Bump hadoop from 3.3.4 -> 3.3.6
Bump zookeeper from 3.8.0 -> 3.8.2
Bump accumulo from 2.1.0 -> 2.1.2